### PR TITLE
Updated prepare script to work on "-current" version of DBpedia

### DIFF
--- a/enhancer/jersey/src/main/resources/templates/imports/doc/multipartcontentitem.ftl
+++ b/enhancer/jersey/src/main/resources/templates/imports/doc/multipartcontentitem.ftl
@@ -134,4 +134,4 @@ curl -v -X POST -H "Accept: text/plain" \
     "${it.serviceUrl}?omitMetadata=true"
 </pre> 
 <p>The response will be of type <code>text/plain</code> and return the string
-<code>"John Smith was born in London."</code>.
+<code>"The Stanbol enhancer can detect famous cities such as Paris and people such as Bob Marley."</code>.

--- a/entityhub/indexing/dbpedia/fetch_prepare.sh
+++ b/entityhub/indexing/dbpedia/fetch_prepare.sh
@@ -67,9 +67,6 @@ wget -c $DBPEDIA/$DBP_I18N/tr/labels_tr.nt.bz2
 wget -c $DBPEDIA/$DBP_I18N/zh/labels_zh.nt.bz2
 wget -c $DBPEDIA/$DBP_I18N/en/short-abstracts_en.nt.bz2
 wget -c $DBPEDIA/$DBP_I18N/en/long-abstracts_en.nt.bz2
-wget -c $DBPEDIA/$DBP_I18N/en/article-categories_en.nt.bz2
-wget -c $DBPEDIA/$DBP_I18N/en/category-labels_en.nt.bz2 
-wget -c $DBPEDIA/$DBP_I18N/en/skos-categories_en.nt.bz2
 
 
 # special handling of the image file that has 5 corrupted entries
@@ -95,9 +92,9 @@ wget -c $DBPEDIA/$DBP_I18N/en/geo-coordinates_en.nt.bz2
 wget -c $DBPEDIA/$DBP_I18N/en/persondata_en.nt.bz2
 
 # Category information
-wget -c $DBPEDIA/$DBP_I18N/en/category_labels_en.nt.bz2
-wget -c $DBPEDIA/$DBP_I18N/en/skos_categories_en.nt.bz2
-wget -c $DBPEDIA/$DBP_I18N/en/article_categories_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/category-labels_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/skos-categories_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/article-categories_en.nt.bz2
 
 # Redirects
 wget -c $DBPEDIA/$DBP_I18N/en/redirects_en.nt.bz2

--- a/entityhub/indexing/dbpedia/fetch_prepare.sh
+++ b/entityhub/indexing/dbpedia/fetch_prepare.sh
@@ -15,11 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build the jar
+mvn package
 
-INDEXING_JAR=`pwd`/target/org.apache.stanbol.entityhub.indexing.dbpedia-*-jar-with-dependencies.jar
+# Get the JAR path
+INDEXING_JAR=$PWD/`ls target/org.apache.stanbol.entityhub.indexing.dbpedia*jar | grep -v sources`
 WORKSPACE=/tmp/dbpedia-index
-DBPEDIA=http://downloads.dbpedia.org/3.7
+DBPEDIA=http://downloads.dbpedia.org/current
 MAX_SORT_MEM=2G
+DBP_I18N=core-i18n
 
 # Turn on echoing and exit on error
 set -x -e -o pipefail
@@ -35,7 +39,8 @@ java -jar $INDEXING_JAR init
 # wikipedia graph: computing this takes around 2 hours
 if [ ! -f $WORKSPACE/indexing/resources/incoming_links.txt ]
 then
-    curl $DBPEDIA/en/page_links_en.nt.bz2 \
+    echo "NB!: Downloading and parsing this file will take several hours"
+    curl $DBPEDIA/$DBP_I18N/en/page-links_en.nt.bz2 \
         | bzcat \
         | sed -e 's/.*<http\:\/\/dbpedia\.org\/resource\/\([^>]*\)> ./\1/' \
         | sort -S $MAX_SORT_MEM \
@@ -47,25 +52,30 @@ fi
 cd $WORKSPACE/indexing/resources/rdfdata
 
 # General attributes for all entities
-wget -c $DBPEDIA/dbpedia_3.7.owl.bz2
-wget -c $DBPEDIA/en/instance_types_en.nt.bz2
-wget -c $DBPEDIA/ar/labels_ar.nt.bz2
-wget -c $DBPEDIA/en/labels_en.nt.bz2
-wget -c $DBPEDIA/es/labels_es.nt.bz2
-wget -c $DBPEDIA/fr/labels_fr.nt.bz2
-wget -c $DBPEDIA/he/labels_he.nt.bz2
-wget -c $DBPEDIA/it/labels_it.nt.bz2
-wget -c $DBPEDIA/ja/labels_ja.nt.bz2
-wget -c $DBPEDIA/ru/labels_ru.nt.bz2
-wget -c $DBPEDIA/tr/labels_tr.nt.bz2
-wget -c $DBPEDIA/zh/labels_zh.nt.bz2
-wget -c $DBPEDIA/en/short_abstracts_en.nt.bz2
-#wget -c $DBPEDIA/en/long_abstracts_en.not.bz2
+DBP_MAIN=`curl -s http://downloads.dbpedia.org/current/ | grep owl.bz2 | cut -f2 -d"\""`
+wget -c $DBPEDIA/$DBP_MAIN
+wget -c $DBPEDIA/$DBP_I18N/en/instance-types_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/ar/labels_ar.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/labels_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/es/labels_es.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/fr/labels_fr.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/he/labels_he.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/it/labels_it.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/ja/labels_ja.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/ru/labels_ru.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/tr/labels_tr.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/zh/labels_zh.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/short-abstracts_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/long-abstracts_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/article-categories_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/category-labels_en.nt.bz2 
+wget -c $DBPEDIA/$DBP_I18N/en/skos-categories_en.nt.bz2
+
 
 # special handling of the image file that has 5 corrupted entries
 if [ ! -f images_en.nt ]
 then
-    wget -c $DBPEDIA/en/images_en.nt.bz2
+    wget -c $DBPEDIA/$DBP_I18N/en/images_en.nt.bz2
     bzcat images_en.nt.bz2 \
       | sed 's/\\\\/\\u005c\\u005c/g;s/\\\([^u"]\)/\\u005c\1/g' > images_en.nt
     rm -f images_en.nt.bz2
@@ -74,23 +84,23 @@ fi
 # same problem for german labels
 if [ ! -f labels_de.nt ]
 then
-    wget -c $DBPEDIA/de/labels_de.nt.bz2
+    wget -c $DBPEDIA/$DBP_I18N/de/labels_de.nt.bz2
     bzcat labels_de.nt.bz2 \
       | sed 's/\\\\/\\u005c\\u005c/g;s/\\\([^u"]\)/\\u005c\1/g' > labels_de.nt
     rm -f labels_de.nt.bz2
 fi
 
 # Type specific attributes
-wget -c $DBPEDIA/en/geo_coordinates_en.nt.bz2
-wget -c $DBPEDIA/en/persondata_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/geo-coordinates_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/persondata_en.nt.bz2
 
 # Category information
-#wget -c $DBPEDIA/en/category_labels_en.nt.bz2
-#wget -c $DBPEDIA/en/skos_categories_en.nt.bz2
-#wget -c $DBPEDIA/en/article_categories_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/category_labels_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/skos_categories_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/article_categories_en.nt.bz2
 
 # Redirects
-wget -c $DBPEDIA/en/redirects_en.nt.bz2
+wget -c $DBPEDIA/$DBP_I18N/en/redirects_en.nt.bz2
 
 set +xe
 

--- a/entityhub/indexing/freebase/fbrankings-uri.sh
+++ b/entityhub/indexing/freebase/fbrankings-uri.sh
@@ -27,8 +27,7 @@ set -x -e -o pipefail
 INCOMING_FILE=${WORKSPACE}/incoming_links.txt
 FB_DUMP=$1
 
-gunzip -c ${FB_DUMP} \
-| grep "^<http://rdf.freebase.com/ns/m\..*<.*>.*<http://rdf.freebase.com/ns/m\." \
+zgrep "^<http://rdf.freebase.com/ns/m\..*<.*>.*<http://rdf.freebase.com/ns/m\." $FB_DUMP\
 | cut -f 3 \
 | sed 's/.*\/ns\/\(.*\)>/\1/g' \
 | sort -S $MAX_SORT_MEM \

--- a/entityhub/indexing/freebase/fbrankings.sh
+++ b/entityhub/indexing/freebase/fbrankings.sh
@@ -27,8 +27,7 @@ set -x -e -o pipefail
 INCOMING_FILE=${WORKSPACE}/incoming_links.txt
 FB_DUMP=$1
 
-gunzip -c ${FB_DUMP} \
-| grep "^ns:m\..*\t.*\tns:m\." \
+zgrep "^ns:m\..*\t.*\tns:m\." $FB_DUMP \
 | cut -f 3 | sed 's/.$//' \
 | sort -S $MAX_SORT_MEM \
 | uniq -c  \


### PR DESCRIPTION
This script will build the indexer, download the **current** version of DBPedia and run the indexer.
