### PR TITLE
Changing the response for a malformed request when using application/x-www-form-urlencoded

### DIFF
--- a/enhancer/jersey/src/main/java/org/apache/stanbol/enhancer/jersey/resource/GenericEnhancerUiResource.java
+++ b/enhancer/jersey/src/main/java/org/apache/stanbol/enhancer/jersey/resource/GenericEnhancerUiResource.java
@@ -135,11 +135,11 @@ public class GenericEnhancerUiResource extends AbstractEnhancerResource {
             //     content parameter
             throw new WebApplicationException( 
                 Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
-                .entity("Parsing Content as 'application/x-www-form-urlencoded' is not supported!"
-                    + "Please directly POST the content and set the 'Content-Type' "
-                    + "header to the media type of the parsed content. 'application/"
-                    + "octet-stream' SHOULD BE used if the media type of the parsed "
-                    + "content is not known.\n")
+                .entity("Parsing Content as 'application/x-www-form-urlencoded' is not officially supported!"
+                    + "Please directly POST the content or if you do want to use the unsupported API,"
+                    + "use the following keys:\n"
+                    + "content => The text to enhance\n"
+                    + "format => Equivalent to the Accept Header\n")
                 .build());
         }
         ContentItem ci = ciFactory.createContentItem(new StringSource(content));


### PR DESCRIPTION
 The previous response was misleading for the user who would think Stanbol doesn't support requests using form data.  Although this is not officially supported, users might want to try it at their own risk and this message tells them how to rather than saying it's not implemented
