### PR TITLE
STANBOL-1468: Change the method name.

### DIFF
--- a/entityhub/ldpath/src/main/java/org/apache/stanbol/entityhub/ldpath/backend/AbstractBackend.java
+++ b/entityhub/ldpath/src/main/java/org/apache/stanbol/entityhub/ldpath/backend/AbstractBackend.java
@@ -217,7 +217,7 @@ public abstract class AbstractBackend implements RDFBackend<Object> {
                     throw new IllegalStateException(e.getMessage(),e);
                 }
                 if(r != null){
-                    toLRU(r);
+                    addToLRU(r);
                 }
             }
             if(r != null){
@@ -384,7 +384,7 @@ public abstract class AbstractBackend implements RDFBackend<Object> {
      * Adds an retrieved Representation to the LRU cache
      * @param r
      */
-    private void toLRU(Representation r){
+    private void addToLRU(Representation r){
         lru.put(r.getId(), r);
     }
     /**


### PR DESCRIPTION
The method "toLRU" is adding the data of the paraement 'r' to the variable "lru", but it is named "toLRU". "toLRU" seems to mean that converting one object to another one, so that "toLRU" may be confusing. "addToLRU" should be better.